### PR TITLE
#1 feat: shared UI and tab view

### DIFF
--- a/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice.xcodeproj/project.pbxproj
+++ b/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		C5ACC805286AC1BD00131D10 /* AppsData.json in Resources */ = {isa = PBXBuildFile; fileRef = C5ACC801286AC1BD00131D10 /* AppsData.json */; };
 		C5ACC806286AC1BD00131D10 /* JSONReadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ACC802286AC1BD00131D10 /* JSONReadTest.swift */; };
 		C5ACC807286AC1BD00131D10 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ACC804286AC1BD00131D10 /* Model.swift */; };
+		C5ACC80F286AC39E00131D10 /* SharedUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ACC80E286AC39E00131D10 /* SharedUI.swift */; };
 		C5FB5E922863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FB5E912863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift */; };
 		C5FB5E942863EB30003C5722 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FB5E932863EB30003C5722 /* ContentView.swift */; };
 		C5FB5E962863EB32003C5722 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5FB5E952863EB32003C5722 /* Assets.xcassets */; };
@@ -21,6 +22,7 @@
 		C5ACC801286AC1BD00131D10 /* AppsData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AppsData.json; sourceTree = "<group>"; };
 		C5ACC802286AC1BD00131D10 /* JSONReadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONReadTest.swift; sourceTree = "<group>"; };
 		C5ACC804286AC1BD00131D10 /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		C5ACC80E286AC39E00131D10 /* SharedUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedUI.swift; sourceTree = "<group>"; };
 		C5FB5E8E2863EB30003C5722 /* CCC-1st-AppStore-Eunice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "CCC-1st-AppStore-Eunice.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5FB5E912863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCC_1st_AppStore_EuniceApp.swift; sourceTree = "<group>"; };
 		C5FB5E932863EB30003C5722 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -76,11 +78,12 @@
 		C5FB5E902863EB30003C5722 /* CCC-1st-AppStore-Eunice */ = {
 			isa = PBXGroup;
 			children = (
+				C5FB5E912863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift */,
+				C5FB5E932863EB30003C5722 /* ContentView.swift */,
+				C5ACC80E286AC39E00131D10 /* SharedUI.swift */,
 				C5ACC800286AC1BD00131D10 /* Data */,
 				C5ACC802286AC1BD00131D10 /* JSONReadTest.swift */,
 				C5ACC803286AC1BD00131D10 /* Model */,
-				C5FB5E912863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift */,
-				C5FB5E932863EB30003C5722 /* ContentView.swift */,
 				C5FB5E952863EB32003C5722 /* Assets.xcassets */,
 				C5FB5E972863EB32003C5722 /* Preview Content */,
 				C5FB5EA02863EE1D003C5722 /* .swiftlint.yml */,
@@ -194,6 +197,7 @@
 				C5FB5E922863EB30003C5722 /* CCC_1st_AppStore_EuniceApp.swift in Sources */,
 				C5ACC806286AC1BD00131D10 /* JSONReadTest.swift in Sources */,
 				C5ACC807286AC1BD00131D10 /* Model.swift in Sources */,
+				C5ACC80F286AC39E00131D10 /* SharedUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice/ContentView.swift
+++ b/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice/ContentView.swift
@@ -9,8 +9,46 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        TabView {
+            TodayView()
+                .tabItem {
+                    VStack {
+                        Image(systemName: "doc.text.image")
+                        Text("투데이")
+                    }
+                }
+            GameView()
+                .tabItem {
+                    VStack {
+                        // 아이콘 수정 필요
+                        Image(systemName: "gamecontroller.fill")
+                        Text("게임")
+                    }
+                }
+            // how to make this shown first?
+            AppsView()
+                .tabItem {
+                    VStack {
+                        Image(systemName: "square.stack.3d.up.fill")
+                        Text("앱")
+                    }
+                }
+            Text("Stub View: Arcade")
+                .tabItem {
+                    VStack {
+                        // 아이콘 교체 필요
+                        Image(systemName: "gamecontroller")
+                        Text("Arcade")
+                    }
+                }
+            Text("Stub View: Search")
+                .tabItem {
+                    VStack {
+                        Image(systemName: "magnifyingglass")
+                        Text("Search")
+                    }
+                }
+        }
     }
 }
 

--- a/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice/SharedUI.swift
+++ b/CCC-1st-AppStore-Eunice/CCC-1st-AppStore-Eunice/SharedUI.swift
@@ -1,0 +1,269 @@
+//
+//  SharedUI.swift
+//  CCC-1st-AppStore-Eunice
+//
+//  Created by Hyorim Nam on 2022/06/24.
+//
+
+import SwiftUI
+
+let screenWidth = UIScreen.main.bounds.width
+
+struct TitleView: View {
+    let appName: String
+    var body: some View {
+        HStack {
+            Text(appName)
+                .font(.largeTitle)
+                .bold()
+            Spacer()
+            Text(Image(systemName: "person.crop.circle"))
+                .font(.largeTitle)
+//                .bold()
+                .foregroundColor(.blue)
+        }
+    }
+}
+
+struct HorizontalCardSection: View {
+    let sectionName: String? = nil
+    @Binding var maincards: [Maincard] // json
+    var body: some View {
+        VStack {
+            if sectionName != nil {
+                Text(sectionName ?? "err")
+                    .font(.title)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(maincards) { maincard in
+                        VStack(alignment: .leading) {
+                            Text(maincard.category)
+                                .font(.footnote)
+                                .foregroundColor(.blue)
+                            Text(maincard.appInfo.title)
+                                .font(.title2)
+                                .multilineTextAlignment(.leading)
+                            if maincard.subtitle != nil {
+                                Text(maincard.subtitle ?? "err")
+                                    .font(.title3)
+                                    .foregroundColor(.gray)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            
+//                            Image(systemName: maincard.image)
+//                                .resizable()
+//                                .scaledToFit()
+                            CardView(maincard: maincard)
+                        }
+//                        .padding()
+                        .frame(width: screenWidth*0.8)
+                        .padding()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct HorizontalListSection: View {
+    @Binding var appList: AppList
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(appList.section)
+                    .font(.title)
+                    .bold()
+                Spacer()
+                Button("모두 보기"){}
+                    .font(.title2)
+            }
+            if appList.subtitle != nil {
+                Text(appList.subtitle!)
+                    .font(.title3)
+                    .foregroundColor(.gray)
+            }
+
+            let rows: [GridItem] = Array(repeating: .init(.flexible()), count: 3)
+            ScrollView(.horizontal, showsIndicators: false) {
+                // https://seons-dev.tistory.com/58
+                LazyHGrid(rows: rows) {
+                    ForEach(appList.data){ datum in
+                        AppListView(data: datum)
+                            //.padding(.vertical)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct AppListView: View {
+    let data: Datum
+    let textColor: Color = Color.primary
+    let last: Bool = false
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+            // 이미지 교체
+                Image(data.appInfo.icon)
+                    .resizable()
+                    //.scaledToFit()
+                    .frame(width: screenWidth*0.15, height: screenWidth*0.15)
+                    //.background(RoundedRectangle(cornerRadius: 6))
+                    //.clipped()
+                    .padding()
+
+                if data.ranking != nil {
+                    VStack(alignment: .leading) {
+                        Text("\(data.ranking!)")
+                        Spacer()
+                    }
+                }
+
+                VStack(alignment: .leading) {
+                    Text(data.appInfo.title)
+                    Text(data.appInfo.subtitle)
+                }
+                Spacer()
+                        // 테스트
+                DownloadVButton(purchased: data.appInfo.purchased, inAppPurchase: data.appInfo.inAppPurchase, installed: data.appInfo.installed, price: data.appInfo.price)
+            }
+            .padding()
+            if !last {
+                Divider()
+            }
+        }
+        .frame(width: screenWidth*0.8)
+    }
+}
+
+struct CardView: View {
+    let maincard: Maincard
+    var body: some View {
+        ZStack {
+            // 이미지 교체 필요
+            Image(maincard.image)
+                .resizable()
+                //.scaledToFit()
+                .frame(width: screenWidth*0.8, height: screenWidth*0.5)
+            VStack {
+                Spacer()
+                // 이미지 수정 필요
+                HStack {
+                    Image( maincard.appInfo.icon)
+                        .resizable()
+                        //.scaledToFit()
+                        .frame(width: screenWidth*0.15, height: screenWidth*0.15)
+                    VStack(alignment: .leading) {
+                        Text(maincard.appInfo.title)
+                            .font(.body)
+                            .lineLimit(1)
+                        Text(maincard.appInfo.subtitle)
+                            .font(.body)
+                            .foregroundColor(.gray)
+                            .lineLimit(1)
+                    }
+                    DownloadVButton(purchased: false, inAppPurchase: true, installed: false, price: 0, textColor: .white)
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 30)
+                        .fill(.white.opacity(0.0))
+                    .blur(radius: 10, opaque: true)
+                )
+            }
+        }
+    }
+}
+
+struct DownloadVButton: View {
+    var purchased: Bool
+    var inAppPurchase: Bool
+    var installed: Bool
+    var price: Int
+    var textColor: Color = .blue
+    @State var pressed = false
+    var body: some View {
+        if installed {
+            Button("열기") {
+                // 앱 열기 <- 안함
+            }
+            .padding(.horizontal)
+            .background(Capsule()
+                .fill(Color(UIColor.systemGray5))
+            )
+        } else {
+            if purchased {
+                Button {
+                } label: {
+                    Text(Image(systemName: "icloud.and.arrow.down"))
+                        .foregroundColor(textColor)
+                    // 돌아가는 다운로드 모션으로 교체 <- 안함
+                }
+            } else {
+                VStack {
+                    Button(price == 0 ? "받기" : "￦\(price)") {
+                        // 돌아가는 모션으로 교체 후 구매 팝업 뜸 <- 안함
+                        // deliberately emptied
+                    }
+                    .foregroundColor(textColor)
+                    .padding(.horizontal)
+                    .background(Capsule()
+                        .fill(Color(UIColor.systemGray5)))
+                    if inAppPurchase {
+                        Text("앱 내 구입")
+                            .font(.caption2)
+                            .foregroundColor(Color(UIColor.systemGray5))
+                    } else {
+                        // 아니면 텍스트 opacity 조정한다거나 흠
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DownloadHButton: View {
+    var purchased: Bool
+    var inAppPurchase: Bool
+    var installed: Bool
+    var price: Int
+    var textColor: Color = .blue
+    @State var pressed = false
+    var body: some View {
+        if installed {
+            Button("열기") {
+                // 앱 열기 <- 안함
+            }
+        } else {
+            if purchased {
+                Button{
+                    
+                } label: {
+                    Text(Image(systemName: "icloud.and.arrow.down"))
+                        .foregroundColor(textColor)
+                    // 돌아가는 다운로드 모션으로 교체 <- 안함
+                }
+            } else {
+                HStack {
+                    Button(price == 0 ? "받기" : "￦\(price)") {
+                        // 돌아가는 모션으로 교체 후 구매 팝업 뜸 <- 안함
+                        // deliberately emptied
+                    }
+                    .padding()
+                    .background(Capsule()
+                        .fill(Color(UIColor.systemGray5)))
+                    if inAppPurchase {
+                        Text("앱 내 구입")
+                    } else {
+                        // 아니면 텍스트 opacity 조정한다거나 흠
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### 작업내용

앱스토어 앱 탭과 게임 탭이 공유하는 컴포넌트를 작성했습니다. 
- 타이틀뷰
- 맨 위의 카드뷰 (스크롤)
  - 이미지와 그 위에 겹치는 뷰
- 앱 중간의 앱 3개씩 있는 리스트 섹션 뷰
  - 위 리스트 안의 한 앱에 대한 항목 뷰
- 앱 받기/금액/열기/클라우드표시 버튼

### 리뷰포인트

### 다음으로 진행될 작업
[] 뷰 그리기
[] 뷰 자세하게 그리기

### 질문

### References
https://seons-dev.tistory.com/entry/SwiftUI-Lazy-VHStack